### PR TITLE
Normalize azhar shortcode admin attributes

### DIFF
--- a/platform/themes/gerow/functions/functions.php
+++ b/platform/themes/gerow/functions/functions.php
@@ -20,7 +20,9 @@ use Botble\Portfolio\Models\Service;
 use Botble\Portfolio\Models\ServiceCategory;
 use Botble\Theme\Facades\Theme;
 use Botble\Theme\Supports\ThemeSupport;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 
 register_page_template([
     'default' => __('Default'),
@@ -464,6 +466,37 @@ app()->booted(function () {
         }
     }, arguments: 3);
 });
+
+if (! function_exists('azhar_normalize_shortcode_attributes')) {
+    /**
+     * Normalize shortcode attributes into a flat array regardless of the provided input type.
+     */
+    function azhar_normalize_shortcode_attributes(array|object $attributes, array $defaults = []): array
+    {
+        if ($attributes instanceof Collection) {
+            $attributes = $attributes->all();
+        } elseif ($attributes instanceof Arrayable) {
+            $attributes = $attributes->toArray();
+        } elseif ($attributes instanceof \Traversable) {
+            $attributes = iterator_to_array($attributes);
+        } elseif (is_object($attributes)) {
+            $attributes = get_object_vars($attributes);
+        }
+
+        if (! is_array($attributes)) {
+            $attributes = [];
+        }
+
+        if ($defaults !== []) {
+            $attributes = array_merge($defaults, $attributes);
+        }
+
+        return array_filter(
+            $attributes,
+            static fn ($value) => $value !== null
+        );
+    }
+}
 
 
 

--- a/platform/themes/gerow/functions/shortcodes.php
+++ b/platform/themes/gerow/functions/shortcodes.php
@@ -26,7 +26,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.hero', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-hero', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-hero', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.hero-admin', compact('attributes'));
     });
 
@@ -34,7 +36,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.company-overview', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-company-overview', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-company-overview', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.company-overview-admin', compact('attributes'));
     });
 
@@ -42,7 +46,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.sectors', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-sectors', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-sectors', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.sectors-admin', compact('attributes'));
     });
 
@@ -50,7 +56,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.newsroom', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-newsroom', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-newsroom', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.newsroom-admin', compact('attributes'));
     });
 
@@ -58,7 +66,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.portfolio', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-portfolio', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-portfolio', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.portfolio-admin', compact('attributes'));
     });
 
@@ -66,7 +76,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.sustainability', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-sustainability', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-sustainability', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.sustainability-admin', compact('attributes'));
     });
 
@@ -74,7 +86,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.subsidiaries', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-subsidiaries', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-subsidiaries', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.subsidiaries-admin', compact('attributes'));
     });
 
@@ -82,7 +96,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.geography', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-geography', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-geography', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.geography-admin', compact('attributes'));
     });
 
@@ -90,7 +106,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.page-hero', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-page-hero', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-page-hero', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.page-hero-admin', compact('attributes'));
     });
 
@@ -98,7 +116,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.explore-more', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-explore-more', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-explore-more', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.explore-more-admin', compact('attributes'));
     });
 
@@ -106,7 +126,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.about-tabs', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-about-tabs', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-about-tabs', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.about-tabs-admin', compact('attributes'));
     });
 
@@ -145,7 +167,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.contact-form', compact('shortcode', 'form'));
     });
 
-    Shortcode::setAdminConfig('azhar-contact-form', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-contact-form', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.contact-form-admin', compact('attributes'));
     });
 
@@ -153,7 +177,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.contact-locations', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-contact-locations', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-contact-locations', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.contact-locations-admin', compact('attributes'));
     });
 
@@ -161,7 +187,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.sustainability-report', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-sustainability-report', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-sustainability-report', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.sustainability-report-admin', compact('attributes'));
     });
 
@@ -169,7 +197,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.esg-strategy', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-esg-strategy', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-esg-strategy', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.esg-strategy-admin', compact('attributes'));
     });
 
@@ -177,7 +207,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.sustainability-approach', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-sustainability-approach', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-sustainability-approach', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.sustainability-approach-admin', compact('attributes'));
     });
 
@@ -185,7 +217,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.sustainability-policies', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-sustainability-policies', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-sustainability-policies', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.sustainability-policies-admin', compact('attributes'));
     });
 
@@ -193,7 +227,9 @@ app()->booted(function () {
         return Theme::partial('shortcodes.azhar.sustainability-initiatives', compact('shortcode'));
     });
 
-    Shortcode::setAdminConfig('azhar-sustainability-initiatives', function (array $attributes): ?string {
+    Shortcode::setAdminConfig('azhar-sustainability-initiatives', function ($attributes): ?string {
+        $attributes = azhar_normalize_shortcode_attributes($attributes);
+
         return Theme::partial('shortcodes.azhar.sustainability-initiatives-admin', compact('attributes'));
     });
 


### PR DESCRIPTION
## Summary
- normalize attributes passed to every azhar-* shortcode admin form so collection inputs can be saved and edited reliably

## Testing
- php -l platform/themes/gerow/functions/shortcodes.php

------
https://chatgpt.com/codex/tasks/task_e_68da8098c858832d9b81ba5650eb9df7