### PR TITLE
Stabilize shortcode repeater serialization

### DIFF
--- a/platform/themes/gerow/partials/shortcodes/azhar/about-tabs-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/about-tabs-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $tabs = data_get($attributes, 'tabs');
+    $tabs = azhar_decode_shortcode_json_attribute($attributes, 'tabs');
 
     if (! is_array($tabs) || empty($tabs)) {
         $customIds = collect(explode(',', data_get($attributes, 'custom_tab_ids', '')))

--- a/platform/themes/gerow/partials/shortcodes/azhar/about-tabs.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/about-tabs.blade.php
@@ -1,6 +1,6 @@
 ﻿@php use Illuminate\Support\Str; @endphp
 @php
-    $tabs = collect(data_get($shortcode, 'tabs', []))
+    $tabs = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'tabs') ?? [])
         ->map(function ($tab) {
             return [
                 'title' => data_get($tab, 'title'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/company-overview-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/company-overview-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $metrics = data_get($attributes, 'metrics');
+    $metrics = azhar_decode_shortcode_json_attribute($attributes, 'metrics');
 
     if (! is_array($metrics) || empty($metrics)) {
         $metrics = collect(range(1, 4))

--- a/platform/themes/gerow/partials/shortcodes/azhar/company-overview.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/company-overview.blade.php
@@ -4,7 +4,7 @@
         $shortcode->description_2 ?? null,
     ])->filter();
 
-    $metrics = collect(data_get($shortcode, 'metrics', []))
+    $metrics = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'metrics') ?? [])
         ->map(function ($metric) {
             $value = data_get($metric, 'value');
             $label = data_get($metric, 'label');

--- a/platform/themes/gerow/partials/shortcodes/azhar/contact-locations-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/contact-locations-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $locations = data_get($attributes, 'locations');
+    $locations = azhar_decode_shortcode_json_attribute($attributes, 'locations');
 
     if (! is_array($locations) || empty($locations)) {
         $locations = collect(range(1, 4))

--- a/platform/themes/gerow/partials/shortcodes/azhar/contact-locations.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/contact-locations.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $locations = collect(data_get($shortcode, 'locations', []))
+    $locations = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'locations') ?? [])
         ->map(function ($location) {
             return (object) [
                 'title' => data_get($location, 'title'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/explore-more-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/explore-more-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $cards = data_get($attributes, 'explore_cards');
+    $cards = azhar_decode_shortcode_json_attribute($attributes, 'explore_cards');
 
     if (! is_array($cards) || empty($cards)) {
         $cards = collect(range(1, 6))

--- a/platform/themes/gerow/partials/shortcodes/azhar/explore-more.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/explore-more.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $cards = collect(data_get($shortcode, 'explore_cards', []))
+    $cards = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'explore_cards') ?? [])
         ->map(function ($card) {
             $title = data_get($card, 'title');
             $url = data_get($card, 'url') ?: '#';

--- a/platform/themes/gerow/partials/shortcodes/azhar/hero-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/hero-admin.blade.php
@@ -2,7 +2,7 @@
 
 @php use Illuminate\Support\Str; @endphp
 @php
-    $slides = data_get($attributes, 'slides');
+    $slides = azhar_decode_shortcode_json_attribute($attributes, 'slides');
 
     if (! is_array($slides) || empty($slides)) {
         $slides = collect(range(1, 5))

--- a/platform/themes/gerow/partials/shortcodes/azhar/hero.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/hero.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $slides = collect(data_get($shortcode, 'slides', []))
+    $slides = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'slides') ?? [])
         ->map(function ($slide) {
             return (object) [
                 'image' => data_get($slide, 'image'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/newsroom-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/newsroom-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $items = data_get($attributes, 'items');
+    $items = azhar_decode_shortcode_json_attribute($attributes, 'items');
 
     if (! is_array($items) || empty($items)) {
         $items = collect(range(1, 3))

--- a/platform/themes/gerow/partials/shortcodes/azhar/newsroom.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/newsroom.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $items = collect(data_get($shortcode, 'items', []))
+    $items = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'items') ?? [])
         ->map(function ($item) {
             return (object) [
                 'title' => data_get($item, 'title'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/portfolio-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/portfolio-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $filters = data_get($attributes, 'filters');
+    $filters = azhar_decode_shortcode_json_attribute($attributes, 'filters');
 
     if (! is_array($filters) || empty($filters)) {
         $filters = collect(range(1, 4))
@@ -23,7 +23,7 @@
             ->all();
     }
 
-    $cards = data_get($attributes, 'cards');
+    $cards = azhar_decode_shortcode_json_attribute($attributes, 'cards');
 
     if (! is_array($cards) || empty($cards)) {
         $cards = collect(range(1, 4))

--- a/platform/themes/gerow/partials/shortcodes/azhar/portfolio.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/portfolio.blade.php
@@ -1,6 +1,6 @@
 ﻿@php use Illuminate\Support\Str; @endphp
 @php
-    $filters = collect(data_get($shortcode, 'filters', []))
+    $filters = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'filters') ?? [])
         ->map(function ($filter) {
             $label = data_get($filter, 'label');
             $value = data_get($filter, 'value');
@@ -32,7 +32,7 @@
         })->filter();
     }
 
-    $cards = collect(data_get($shortcode, 'cards', []))
+    $cards = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'cards') ?? [])
         ->map(function ($card) {
             return (object) [
                 'category' => data_get($card, 'category'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/sectors-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/sectors-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $cards = data_get($attributes, 'cards');
+    $cards = azhar_decode_shortcode_json_attribute($attributes, 'cards');
 
     if (! is_array($cards) || empty($cards)) {
         $cards = collect(range(1, 6))

--- a/platform/themes/gerow/partials/shortcodes/azhar/sectors.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/sectors.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $cards = collect(data_get($shortcode, 'cards', []))
+    $cards = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'cards') ?? [])
         ->map(function ($card) {
             return (object) [
                 'title' => data_get($card, 'title'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/subsidiaries-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/subsidiaries-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $headerLinks = data_get($attributes, 'header_links');
+    $headerLinks = azhar_decode_shortcode_json_attribute($attributes, 'header_links');
 
     if (! is_array($headerLinks) || empty($headerLinks)) {
         $headerLinks = collect(range(1, 3))

--- a/platform/themes/gerow/partials/shortcodes/azhar/subsidiaries.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/subsidiaries.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $links = collect(data_get($shortcode, 'header_links', []))
+    $links = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'header_links') ?? [])
         ->map(function ($link) {
             $label = data_get($link, 'label');
             $url = data_get($link, 'url');
@@ -31,7 +31,7 @@
         })->filter();
     }
 
-    $items = collect(data_get($shortcode, 'items', []))
+    $items = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'items') ?? [])
         ->map(function ($item) {
             return (object) [
                 'image' => data_get($item, 'image'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/sustainability-initiatives-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/sustainability-initiatives-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $cards = data_get($attributes, 'cards');
+    $cards = azhar_decode_shortcode_json_attribute($attributes, 'cards');
 
     if (! is_array($cards) || empty($cards)) {
         $cards = collect(range(1, 6))

--- a/platform/themes/gerow/partials/shortcodes/azhar/sustainability-initiatives.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/sustainability-initiatives.blade.php
@@ -1,7 +1,7 @@
 ﻿@php
     $label = $shortcode->label ?? null;
     $title = $shortcode->title ?? null;
-    $cards = collect(data_get($shortcode, 'cards', []))
+    $cards = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'cards') ?? [])
         ->map(function ($card) {
             return (object) [
                 'category' => data_get($card, 'category'),

--- a/platform/themes/gerow/partials/shortcodes/azhar/sustainability-policies-admin.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/sustainability-policies-admin.blade.php
@@ -1,7 +1,7 @@
 ﻿@include(Theme::getThemeNamespace() . '::partials.shortcodes.azhar._repeater-assets')
 
 @php
-    $items = data_get($attributes, 'items');
+    $items = azhar_decode_shortcode_json_attribute($attributes, 'items');
 
     if (! is_array($items) || empty($items)) {
         $items = collect(range(1, 4))

--- a/platform/themes/gerow/partials/shortcodes/azhar/sustainability-policies.blade.php
+++ b/platform/themes/gerow/partials/shortcodes/azhar/sustainability-policies.blade.php
@@ -1,5 +1,5 @@
 ﻿@php
-    $newItems = collect(data_get($shortcode, 'items', []))
+    $newItems = collect(azhar_decode_shortcode_json_attribute($shortcode->toArray(), 'items') ?? [])
         ->map(function ($item) {
             return (object) [
                 'icon' => data_get($item, 'icon'),

--- a/public/vendor/azharcms/azhar-shortcode-repeater.js
+++ b/public/vendor/azharcms/azhar-shortcode-repeater.js
@@ -1,8 +1,14 @@
-﻿(function ($) {
+(function ($) {
     'use strict';
 
-    if (!$.fn._azharSerializeObjectPatched) {
-        $.fn._azharSerializeObjectPatched = true;
+    function patchSerializeObject() {
+        if ($.fn._azharSerializeObjectPatched) {
+            return;
+        }
+
+        if (typeof $.fn.serializeObject !== 'function') {
+            return;
+        }
 
         const originalSerializeObject = $.fn.serializeObject;
 
@@ -28,11 +34,21 @@
 
             return result;
         };
+
+        $.fn._azharSerializeObjectPatched = true;
     }
+
+    patchSerializeObject();
 
     function markRepeaterInputs($container) {
         $container.find(':input[name]').each(function () {
-            $(this).attr('data-azhar-repeater-input', 'true');
+            const $input = $(this);
+
+            if ($input.is('[data-azhar-repeater-json]')) {
+                return;
+            }
+
+            $input.attr('data-azhar-repeater-input', 'true');
         });
     }
 
@@ -112,6 +128,14 @@
         $target.val(JSON.stringify(items));
     }
 
+    function syncAllRepeaters(context) {
+        const $context = context ? $(context) : $(document);
+
+        $context.find('.azhar-repeater').each(function () {
+            syncRepeaterData($(this));
+        });
+    }
+
     function bindRepeaterEvents($wrapper) {
         $wrapper.on('change.azharRepeater keyup.azharRepeater', ':input', function () {
             syncRepeaterData($wrapper);
@@ -119,6 +143,8 @@
     }
 
     function initRepeaters(context) {
+        patchSerializeObject();
+
         const $context = context ? $(context) : $(document);
 
         $context.find('.azhar-repeater').each(function () {
@@ -171,6 +197,7 @@
 
     window.AzharShortcodeRepeater = {
         init: initRepeaters,
+        syncAll: syncAllRepeaters,
     };
 
     $(document).ready(function () {
@@ -183,5 +210,13 @@
 
     $(document).on('botble.plugin.shortcode.init', function (event) {
         initRepeaters(event.target);
+    });
+
+    $(document).on('core-shortcode-config-loaded', function (event) {
+        initRepeaters(event.target);
+    });
+
+    $(document).on('click.azharRepeater', '[data-bb-toggle="shortcode-add-single"]', function () {
+        syncAllRepeaters($('.shortcode-data-form'));
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- guard the serializeObject patch until the shortcode helper is available and expose a global sync helper
- resync shortcode repeater JSON when modals initialize and right before saving so widget data persists in CKEditor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc94ee164832db6eabdebdd83e285